### PR TITLE
make image generation more secure

### DIFF
--- a/app/api/user-image-count/route.ts
+++ b/app/api/user-image-count/route.ts
@@ -21,6 +21,7 @@ export async function GET() {
     }
 
     const { subscription_tier, image_count } = result.rows[0];
+
     let limit = 0;
 
     if (subscription_tier === "pro") {
@@ -35,7 +36,6 @@ export async function GET() {
       limit = Number(process.env.NEXT_PUBLIC_FREE_PLAN_IMAGE_GENERATION_LIMIT);
     }
 
-    console.log("limit: " + limit);
     const remainingGenerations = Math.max(0, limit - image_count);
 
     return NextResponse.json({
@@ -82,12 +82,20 @@ export async function POST() {
     }
 
     const { subscription_tier, image_count } = result.rows[0];
-    const limit =
-      subscription_tier === "pro"
-        ? Number(process.env.PRO_PLAN_IMAGE_GENERATION_LIMIT)
-        : subscription_tier === "basic"
-        ? Number(process.env.BASIC_PLAN_IMAGE_GENERATION_LIMIT)
-        : Number(process.env.FREE_PLAN_IMAGE_GENERATION_LIMIT);
+
+    let limit = 0;
+
+    if (subscription_tier === "pro") {
+      limit = Number(process.env.NEXT_PUBLIC_PRO_PLAN_IMAGE_GENERATION_LIMIT);
+    }
+
+    if (subscription_tier === "basic") {
+      limit = Number(process.env.NEXT_PUBLIC_BASIC_PLAN_IMAGE_GENERATION_LIMIT);
+    }
+
+    if (subscription_tier === "free") {
+      limit = Number(process.env.NEXT_PUBLIC_FREE_PLAN_IMAGE_GENERATION_LIMIT);
+    }
 
     if (image_count > limit) {
       return NextResponse.json(


### PR DESCRIPTION
The purpose of this PR is to make the process of generating AI images more secure. We want to make sure that before we call the replicate API, which costs us money, that the user is allowed to make a generation. That means that we check how many generations the user can make:

1. when the page loads - if not, then the generate button is disabled
2. when they click generate- if not, then we error.

One benefit of this refactor is that we are able to show users how many generations they have left immediately when an image is successfully generated. 